### PR TITLE
Make API calls sequentially, not all at once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,21 +152,17 @@ const main = async () => {
 
     const estimates: EstimateResult[] = await Promise.all(
         parsedCSV.map(async (journey) => {
-            let payload
-            try {
-                payload = buildEstimatePayload(journey)
-                const estimateResponse = await client.createMultiLegShippingEstimate(payload)
-                if (estimateResponse.err) {
-                    throw new Error(
-                        (estimateResponse.val as ApiError)?.description ||
-                            estimateResponse?.val?.errors?.errors[0].toString(),
-                    )
-                }
-                return estimateResponse.unwrap()
-            } catch (e) {
-                console.log(`Failed to create estimate for ${journey.shipment_id}: `, e)
-                return { err: (e as Error).message }
+            const payload = buildEstimatePayload(journey)
+            const estimateResponse = await client.createMultiLegShippingEstimate(payload)
+            if (estimateResponse.err) { 
+                const apiError = estimateResponse.val
+                const description = (apiError as ApiError)?.description || apiError.errors?.errors[0].toString()
+                console.log(`Failed to create estimate for ${journey.shipment_id}: `, description)
+                // TODO: This type assertion shouldn't be necessary, we won't ever get
+                // undefined here
+                return { err: description as string }
             }
+            return estimateResponse.unwrap()
         }),
     )
 


### PR DESCRIPTION
Making an unbounded number of concurrent API calls was not necessary for small number of inputs (little to no gain) and actively detrimental in case of larger ones (the Lune API enforces rate limits and the code would easily hit them[1]).

[1] It's still totally possible and likely to reach the rate limits,
    code to handle that to come in a separate PR (retries).