### PR TITLE
Update the Lune client to 2.2.4 (the latest version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,9 @@
   },
   "homepage": "https://github.com/lune-climate/lune-csv-calculator#readme",
   "dependencies": {
-    "@lune-climate/lune": "^2.0.8",
+    "@lune-climate/lune": "^2.2.4",
     "@types/minimist": "^1.2.2",
     "@types/node": "^18.7.13",
-    "camelcase-keys": "^6.2.2",
     "cli-progress": "^3.11.2",
     "csv-parse": "^5.3.0",
     "csv-stringify": "^6.2.0",
@@ -35,7 +34,6 @@
     "nodemon": "^2.0.19",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
-    "snakecase-keys": "^4.0.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "csv-parse": "^5.3.0",
     "csv-stringify": "^6.2.0",
     "dotenv": "^16.0.1",
-    "minimist": "^1.2.6",
-    "snakecase-keys": "^4.0.2"
+    "minimist": "^1.2.6"
   },
   "devDependencies": {
     "@types/cli-progress": "^3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,12 +61,14 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@lune-climate/lune@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@lune-climate/lune/-/lune-2.0.8.tgz#33cbb0b9ac817997e70321d3495b8cc2aee028f8"
-  integrity sha512-rDrrRLqEyV2ROZshJEhj1ldicD2lZZMiFvo5Qmr/JTw70TbKNGmjvpoaer1/xMZh3eCMR+GzGoRlTrHctTpcyg==
+"@lune-climate/lune@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@lune-climate/lune/-/lune-2.2.4.tgz#39800d9027218cf99d787d2e0cdac1752bcbd0de"
+  integrity sha512-GHrHNGsCXg3XGm8JjRN+ZWSQjJo36u+PA3fcfZAFswnz06NM5UGXXZWLl9tH8eLJ8rsgOYp0fpNn+ukvdoV1qA==
   dependencies:
     axios "^0.21.1"
+    camelcase-keys "^6.2.2"
+    snakecase-keys "^5.0.0"
     ts-results-es "^3.4.0"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -1140,13 +1142,14 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-snakecase-keys@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/snakecase-keys/-/snakecase-keys-4.0.2.tgz#72e28112b77753a68a4eeb110efec05ab391e190"
-  integrity sha512-ZFCo3zZtNN43cy2j4fQDHPxS557Uuzn887FBmDdaSB41D8l/MayuvaSrIlCXGFhZ8sXwrHiNaZiIPpKzi88gog==
+snakecase-keys@^5.0.0:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/snakecase-keys/-/snakecase-keys-5.4.4.tgz#28745b0175863ffc292ad97d96fe4e8e288a87a2"
+  integrity sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==
   dependencies:
     map-obj "^4.1.0"
     snake-case "^3.0.4"
+    type-fest "^2.5.2"
 
 string-width@^4.2.3:
   version "4.2.3"
@@ -1254,6 +1257,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^2.5.2:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typescript@^4.7.4:
   version "4.7.4"


### PR DESCRIPTION
Just keeping this up to date. Since the client library now correctly depends on camelcase-keys and snakecase-keys (there was an issue in older versions of the library) we can ourselves stop depending on these libraries directly.