### PR TITLE
Stop using dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-API_KEY="your_api_key"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install this utility and start using it, first perform the following steps:
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
 (typically Terminal on OSX or Command Prompt on Windows)
 3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
-will result in an error `Please set API_KEY in .env`
+will result in an error `Please set the API_KEY environment variable`
 
 ## How to use
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "cli-progress": "^3.11.2",
     "csv-parse": "^5.3.0",
     "csv-stringify": "^6.2.0",
-    "dotenv": "^16.0.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "minimist": "^1.2.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import {
     SimpleShippingMethod,
 } from '@lune-climate/lune'
 import { mapLegToLocation, parseCSV, sleep, trimAndRemoveEmptyEntries, writeResultsToCSV } from './utils'
-import 'dotenv/config'
 import { ApiError } from '@lune-climate/lune/cjs/core/ApiError'
 import { estimatePayload, EstimateResult, LegFromCSV } from './types'
 
@@ -139,7 +138,7 @@ const groupJourneyIntoLegs = (journey: Record<string, string>): Record<number, L
 const main = async () => {
     const pathToCSVFile = process.argv[2]
     if (!process.env.API_KEY) {
-        console.log('Please set API_KEY in .env')
+        console.log('Please set the API_KEY environment variable')
         return
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,11 +450,6 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dotenv@^16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
-  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"


### PR DESCRIPTION
It doesn't provide us any benefits in development (modifying .env forces us to keep ignoring the changes in the working directory) or in npm-/yarn-installed version (*where* would the end-user find the .env file to modify?).

It's both enough and easier for the user to provide the environment variable directly (as the readme already documents), fewer moving pieces.