### PR TITLE
Bump the version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lune-shipping-csv-tool",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "scripts": {
     "dev": "nodemon",
     "build": "rimraf ./build && tsc",


### PR DESCRIPTION
This is to allow us to publish a new version to NPM. I went for the minor number change because we have some new features.