### PR TITLE
Only recompile when there are changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "1.1.0",
   "scripts": {
     "dev": "nodemon",
-    "build": "rimraf ./build && tsc",
+    "build": "tsc --build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npm run build && node build/index.js",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "preinstall": "rimraf build/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Turns out tsc has this --build switch[1] that only type checks and build the code when any of the input files changed. This brings the time to run "yarn build" with no changes present down to ~0.3 s in my Docker environment (compared to ~5 s previously). Full rebuilds still take ~5 seconds, naturally.

A build/ cleanup has been added on dependency installation because tsc --build doesn't handle node_modules changes well.

I went with preinstall instead of postinstall so that on every *attempt* to install dependencies we remove the files – this way even if someone interrupts the package installation we always remove the files first so we're not left in a state where we have the old build directory but some dependencies already changed (no race conditions).

[1] https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript