### PR TITLE
Document what OSes do we support and how

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ This is done via using the [Lune API](https://docs.lune.co).
 
 ## How to install
 
-This utility is a NodeJS application and you should be able to run it on variety of OSes.
+This utility is a NodeJS application and you should be able to run it on variety of OSes
+(more details on this below).
 
 To install this utility and start using it, first perform the following steps:
 
 ### Installing from NPM (AKA "I just want to use the application")
+
+This is supported on Unix-like (Linux, BSD, macOS, Windows with WSL etc.) and Windows (without
+WSL).
 
 1. Install Node if you don't have it already: https://nodejs.org/en/
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
@@ -21,6 +25,8 @@ To install this utility and start using it, first perform the following steps:
 will result in an error `Please set the API_KEY environment variable`
 
 ### Running the development version (AKA "I want to see how it works or make some changes")
+
+This requires a Unix-like operating system (Linux, BSD, macOS, Windows with WSL etc.).
 
 1. Clone this repository
 2. Install Node if you don't have it already


### PR DESCRIPTION
We've made some attempts to keep this package Windows-compatible in all cases (like using rimraf instead of rm -rf to remove directories) but this has proven untenable – not a single person in the company develops on Windows and it's easy to introduce Unix-only development-only incompatibilities. Case in point, there are two package.json scripts that won't work on Windows:

    "test": "echo \"Error: no test specified\" && exit 1",
    "start": "npm run build && node build/index.js",

A good middle ground is to keep the package distributed to NPM Windows-compatible (which is doable) but have no such requirements for code that runs only during development and running the code directly.