### PR TITLE
Stop pretending we support Windows for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && node build/index.js",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
     "lint": "eslint . --ext .ts",
-    "preinstall": "rimraf build/*"
+    "preinstall": "rm -rf build/*"
   },
   "repository": {
     "type": "git",
@@ -39,7 +39,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "nodemon": "^2.0.19",
     "prettier": "^2.7.1",
-    "rimraf": "^3.0.2",
     "typescript": "^4.7.4"
   },
   "bin": {


### PR DESCRIPTION
We're already incompatible (the start and test package.json scripts for example) and it's annoying to have Windows-specific workarounds in place, especially when we all run Unix-like systems.

The version of the package published to NPM remains Windows-compatible and end users fetching it from there aren't affected.