### PR TITLE
Include prettier in the lint task

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npm run build && node build/index.js",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "lint": "eslint . --ext .ts",
+    "lint": "eslint . --ext .ts && prettier --config .prettierrc --check 'src/**/*.ts'",
     "preinstall": "rimraf build/*"
   },
   "repository": {


### PR DESCRIPTION
I figured if we have prettier in the dependencies and we have a configuration for it might as well enforce prettier formatting through the lint script.