### PR TITLE
Rename API_KEY to LUNE_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,31 @@ This utility is a CLI application that parses a CSV file, makes a request to the
 new CSV file with the estimated CO2 emissions.
 
 You will need a valid Lune API key (you can generate one from https://dashboard.lune.co/developers) - it doesn't matter if 
-it's a live/test key.
+it's a live/test key. The application expects the API key to be provided to it via an `API_KEY`
+environment variable:
+
+```
+# Unix-like
+export API_KEY=<the API key secret goes here>
+
+# Windows
+set API_KEY=<The API key secret goes here>
+```
 
 You will also need to create a CSV input file. Please examine [this existing file](https://github.com/lune-climate/lune-shipping-csv-tool/blob/master/input/sampleInput.csv)
 to understand the format.
+
+Then to actually run the tool:
+
+```bash
+lune-csv-calculator <path to the input CSV file>
+```
+
+The output file will appear in the current directory. If you want to define the output directory:
+
+```bash
+lune-csv-calculator <path to the input CSV file> -o <path to the output directory>
+```
 
 ## The CSV Input format
 
@@ -81,36 +102,3 @@ Additionally, the following columns should be present but left empty:
 * `leg1_total_tco2_` -> the estimated CO2 emissions of the leg in kg. Populated by the tool after running
 
 You can provide up to 10 legs in this way. Checkout the sample input to get a better idea.
-
-## Run a calculation
-
-Create a CSV on your machine in some folder. Let's say it's `sampleInput.csv` within /downloads.\
-
-Now start the command line interpreter within that folder. You will need to provide the API key 
-as an environment variable `API_KEY` and also provide the path to the input file.
- 
-Here's what that looks like in the OSX terminal:
-```bash
-
-# The NPM version
-API_KEY=your_api_key_here lune-csv-calculator sampleInput.csv
-
-# The development (GitHub) version
-yarn start sampleInput.csv
-```
-
-And in the Windows command prompt:
-```powershell
-set API_KEY=your_api_key_here
-
-# The NPM version
-lune-csv-calculator sampleInput.csv
-
-# The development (GitHub) version
-yarn start sampleInput.csv
-```
-where `input/sampleInput.csv` is the name of the input file you want to process. The output file will be created in the provided output (-o) folder or 
-the project root if no output folder is provided.\
-
-The output file will then be created in the same folder and will contain a timestamp e.g. `downloads/sampleInput_1662112271931.csv`
-The result is the same CSV file with the result columns filled in (checkout the [sample output file](https://github.com/lune-climate/lune-shipping-csv-tool/blob/master/output/sampleInput_1662043831339.csv)).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 1. Install Node if you don't have it already: https://nodejs.org/en/
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
 (typically Terminal on OSX or Command Prompt on Windows)
+3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
+will result in an error `Please set the API_KEY environment variable`
 
 Now follow the [How to use](#how-to-use) instructions.
 
@@ -27,6 +29,7 @@ This requires a Unix-like operating system (Linux, BSD, macOS, Windows with WSL 
 2. Install Node if you don't have it already
 3. Install a package manager if you don't have it already
 4. Install all dependencies via  `npm install` or `yarn` depending on your package manager of choice
+5. Run the utility via `npm run start` or `yarn start` depending on your package manager of choice
 
 Now follow the [How to use](#how-to-use) instructions. Remember to mentally replace all
 `lune-csv-calculator` occurrences with `yarn start` (or `npm run start`, if you use `npm`) – you

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ will result in an error `Please set the LUNE_API_KEY environment variable`
 
 Now follow the [How to use](#how-to-use) instructions.
 
-Now follow the [How to use](#how-to-use) instructions.
-
 Run `npm update -g lune-shipping-csv-tool` to update the tool to the latest version (note
 that new versions may introduce some backwards-incompatible changes).
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 1. Install Node if you don't have it already: https://nodejs.org/en/
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
 (typically Terminal on OSX or Command Prompt on Windows)
-3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
-will result in an error `Please set the API_KEY environment variable`
+
+Now follow the [How to use](#how-to-use) instructions.
 
 Run `npm update -g lune-shipping-csv-tool` to update the tool to the latest version (note
 that new versions may introduce some backwards-incompatible changes).
@@ -27,7 +27,10 @@ This requires a Unix-like operating system (Linux, BSD, macOS, Windows with WSL 
 2. Install Node if you don't have it already
 3. Install a package manager if you don't have it already
 4. Install all dependencies via  `npm install` or `yarn` depending on your package manager of choice
-5. Run the utility via `npm run start` or `yarn start` depending on your package manager of choice
+
+Now follow the [How to use](#how-to-use) instructions. Remember to mentally replace all
+`lune-csv-calculator` occurrences with `yarn start` (or `npm run start`, if you use `npm`) – you
+are running the development version after all.
 
 Run `git` commands to update the local clone of the repository with the latest upstream changes
 (note that some of them may be backwards-incompatible).
@@ -50,7 +53,7 @@ set API_KEY=<The API key secret goes here>
 ```
 
 You will also need to create a CSV input file. Please examine [this existing file](https://github.com/lune-climate/lune-shipping-csv-tool/blob/master/input/sampleInput.csv)
-to understand the format.
+to understand the format. We have documented [The CSV Input format](#the-csv-input-format).
 
 Then to actually run the tool:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
 (typically Terminal on OSX or Command Prompt on Windows)
 3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
-will result in an error `Please set the API_KEY environment variable`
+will result in an error `Please set the LUNE_API_KEY environment variable`
 
 Now follow the [How to use](#how-to-use) instructions.
 
@@ -44,15 +44,15 @@ This utility is a CLI application that parses a CSV file, makes a request to the
 new CSV file with the estimated CO2 emissions.
 
 You will need a valid Lune API key (you can generate one from https://dashboard.lune.co/developers) - it doesn't matter if 
-it's a live/test key. The application expects the API key to be provided to it via an `API_KEY`
+it's a live/test key. The application expects the API key to be provided to it via an `LUNE_API_KEY`
 environment variable:
 
 ```
 # Unix-like
-export API_KEY=<the API key secret goes here>
+export LUNE_API_KEY=<the API key secret goes here>
 
 # Windows
-set API_KEY=<The API key secret goes here>
+set LUNE_API_KEY=<The API key secret goes here>
 ```
 
 You will also need to create a CSV input file. Please examine [this existing file](https://github.com/lune-climate/lune-shipping-csv-tool/blob/master/input/sampleInput.csv)

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,8 @@ const groupJourneyIntoLegs = (journey: Record<string, string>): Record<number, L
 
 const main = async () => {
     const pathToCSVFile = process.argv[2]
-    if (!process.env.API_KEY) {
-        console.log('Please set the API_KEY environment variable')
+    if (!process.env.LUNE_API_KEY) {
+        console.log('Please set the LUNE_API_KEY environment variable')
         return
     }
 
@@ -155,7 +155,7 @@ const main = async () => {
     }
 
     const parsedCSV: any[] = await parseCSV(pathToCSVFile)
-    const client = new LuneClient(process.env.API_KEY)
+    const client = new LuneClient(process.env.LUNE_API_KEY)
 
     const progressBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic)
     progressBar.start(parsedCSV.length, 0)


### PR DESCRIPTION
API_KEY is a little bit too generic, let's give it a prefix so it's clear what is it and to avoid clashes with other software and other API keys.