### PR TITLE
Stop calling prettier explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "build": "tsc --build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npm run build && node build/index.js",
-    "fix": "eslint . --ext .ts --fix && prettier --config .prettierrc 'src/**/*.ts' --write",
-    "lint": "eslint . --ext .ts && prettier --config .prettierrc --check 'src/**/*.ts'",
+    "fix": "eslint . --ext .ts --fix",
+    "lint": "eslint . --ext .ts",
     "preinstall": "rm -rf build/*",
     "ci": "yarn lint && yarn build"
   },


### PR DESCRIPTION
We have the eslint-plugin-prettier enabled so all prettier issues are already detected by eslint (and fixed with --fix when possible).