### PR TITLE
Remove application argument parsing from writeResultsToCSV()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ import {
 } from '@lune-climate/lune'
 import { ApiError } from '@lune-climate/lune/cjs/core/ApiError'
 import cliProgress from 'cli-progress'
+import fs from 'fs'
+import minimist from 'minimist'
+import path from 'path'
 
 import { estimatePayload, EstimateResult, LegFromCSV } from './types.js'
 import {
@@ -214,9 +217,20 @@ async function main() {
     }
     progressBar.stop()
 
+    const argv = minimist(process.argv.slice(2))
+    const nameOfCSVFile = path.parse(process.argv[2]).name
+    const outputFilePath = `${argv.o || '.'}/${nameOfCSVFile}_${Date.now()}.csv`
+
+    if (argv.o && !fs.existsSync(argv.o)) {
+        fs.mkdirSync(argv.o, {
+            recursive: true,
+        })
+    }
+
     writeResultsToCSV({
         pathToShippingDataCSV: pathToCSVFile,
         results: estimates,
+        outputFilePath,
     })
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,11 @@
 import { createReadStream } from 'fs'
 import fs from 'fs'
-import path from 'path'
 
 import { Address, GeographicCoordinates } from '@lune-climate/lune'
 import { MultiLegShippingEmissionEstimate } from '@lune-climate/lune/esm/models/MultiLegShippingEmissionEstimate'
 import { parse } from 'csv-parse'
 import { parse as parseSync } from 'csv-parse/sync'
 import { stringify } from 'csv-stringify/sync'
-import minimist from 'minimist'
 
 import { EstimateResult, LegFromCSV } from './types.js'
 
@@ -94,9 +92,11 @@ export async function parseCSV(filename: string) {
 export function writeResultsToCSV({
     pathToShippingDataCSV,
     results,
+    outputFilePath,
 }: {
     pathToShippingDataCSV: string
     results: EstimateResult[]
+    outputFilePath: string
 }) {
     const parsedCSV = parseSync(fs.readFileSync(pathToShippingDataCSV))
 
@@ -148,16 +148,7 @@ export function writeResultsToCSV({
         }
     })
 
-    const argv = minimist(process.argv.slice(2))
-    const nameOfCSVFile = path.parse(process.argv[2]).name
-
-    if (argv.o && !fs.existsSync(argv.o)) {
-        fs.mkdirSync(argv.o, {
-            recursive: true,
-        })
-    }
-
-    fs.writeFileSync(`${argv.o || '.'}/${nameOfCSVFile}_${Date.now()}.csv`, stringify(parsedCSV))
+    fs.writeFileSync(outputFilePath, stringify(parsedCSV))
 }
 
 /**


### PR DESCRIPTION
It's easier to know what's going on if the function doesn't refer to global variables to accepts the file path as a parameter.