### PR TITLE
Remove CSV file reading from writeResultsToCSV()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ import {
 } from '@lune-climate/lune'
 import { ApiError } from '@lune-climate/lune/cjs/core/ApiError'
 import cliProgress from 'cli-progress'
+import fs from 'fs'
+import minimist from 'minimist'
+import path from 'path'
 
 import { estimatePayload, EstimateResult, LegFromCSV } from './types.js'
 import {
@@ -214,9 +217,20 @@ async function main() {
     }
     progressBar.stop()
 
+    const argv = minimist(process.argv.slice(2))
+    const nameOfCSVFile = path.parse(process.argv[2]).name
+    const outputFilePath = `${argv.o || '.'}/${nameOfCSVFile}_${Date.now()}.csv`
+
+    if (argv.o && !fs.existsSync(argv.o)) {
+        fs.mkdirSync(argv.o, {
+            recursive: true,
+        })
+    }
+
     writeResultsToCSV({
         pathToShippingDataCSV: pathToCSVFile,
         results: estimates,
+        outputFilePath,
     })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ async function main() {
     }
 
     writeResultsToCSV({
-        pathToShippingDataCSV: pathToCSVFile,
+        inputs: parsedCSV,
         results: estimates,
         outputFilePath,
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+import fs from 'fs'
+import path from 'path'
+
 import {
     ContainerShippingMethod,
     Distance,
@@ -7,9 +10,7 @@ import {
     SimpleShippingMethod,
 } from '@lune-climate/lune'
 import cliProgress from 'cli-progress'
-import fs from 'fs'
 import minimist from 'minimist'
-import path from 'path'
 
 import { estimatePayload, EstimateResult, LegFromCSV } from './types.js'
 import {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ export function writeResultsToCSV({
 }) {
     // We'll be modifying the inputs inside – deep copy them so that our
     // changes aren't visible outside this function.
-    inputs = inputs.map((i) => ({...i}))
+    inputs = inputs.map((i) => ({ ...i }))
 
     results.forEach((result, index) => {
         const csvRow = inputs[index]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,11 @@
 import { createReadStream } from 'fs'
 import fs from 'fs'
-import path from 'path'
 
 import { Address, GeographicCoordinates } from '@lune-climate/lune'
 import { MultiLegShippingEmissionEstimate } from '@lune-climate/lune/esm/models/MultiLegShippingEmissionEstimate'
 import { parse } from 'csv-parse'
 import { parse as parseSync } from 'csv-parse/sync'
 import { stringify } from 'csv-stringify/sync'
-import minimist from 'minimist'
 
 import { EstimateResult, LegFromCSV } from './types.js'
 
@@ -94,9 +92,11 @@ export async function parseCSV(filename: string) {
 export function writeResultsToCSV({
     pathToShippingDataCSV,
     results,
+    outputFilePath,
 }: {
     pathToShippingDataCSV: string
     results: EstimateResult[]
+    outputFilePath: string
 }) {
     const parsedCSV = parseSync(fs.readFileSync(pathToShippingDataCSV))
 
@@ -148,16 +148,7 @@ export function writeResultsToCSV({
         }
     })
 
-    const argv = minimist(process.argv.slice(2))
-    const nameOfCSVFile = path.parse(process.argv[2]).name
-
-    if (argv.o && !fs.existsSync(argv.o)) {
-        fs.mkdirSync(argv.o, {
-            recursive: true,
-        })
-    }
-
-    fs.writeFileSync(`${argv.o || '.'}/${nameOfCSVFile}_${Date.now()}.csv`, stringify(parsedCSV))
+    fs.writeFileSync(outputFilePath, stringify(parsedCSV))
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
+    "allowJs": true,
     "outDir": "build",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "rootDir": "src",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "allowJs": true,
     "outDir": "build",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
It's kind of unexpected that a function called writeResultsToCSV() reads files and parses CSV so let's remove that. The long-term goal is to make this code more unit-testable too.