### PR TITLE
Stop allowing importing pure JS code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "rootDir": "src",
     "moduleResolution": "Node",
     "resolveJsonModule": true,
-    "allowJs": true,
     "outDir": "build",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This is a TS project and we have no need for this right now. Type check everything and don't provide escape hatches.