### PR TITLE
Report test coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn ci
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts",
     "preinstall": "rm -rf build/*",
-    "ci": "yarn lint && yarn test"
+    "ci": "yarn lint && yarn test --coverage"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts",
     "preinstall": "rm -rf build/*",
-    "ci": "yarn lint && yarn test --coverage"
+    "ci": "yarn lint && yarn test --coverage --collectCoverageFrom='./src/**'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It lets us see right away what's tested and what's not (right now: everything's the latter), Codecov has nice code browser with coverage visible right there.

The --collectCoverageFrom parameter allows us to include all source files in the report so that ones that are never used are reported as not covered.