### PR TITLE
Support ESM imports in tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,4 +2,5 @@ module.exports = {
   transform: {
     "^.+\\.(t|j)sx?$": ["@swc/jest"],
   },
+  extensionsToTreatAsEsm: [".ts"],
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,5 +2,7 @@ module.exports = {
   transform: {
     "^.+\\.(t|j)sx?$": ["@swc/jest"],
   },
-  extensionsToTreatAsEsm: [".ts"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 };


### PR DESCRIPTION
.js extensions are required in ESM code (which ours is) but we need to tell jest how to actually find the modules to import (it doesn't understand ESM by out of the box).

    $ /lune/lune-shipping-csv-tool/node_modules/.bin/jest src/ --coverage '--collectCoverageFrom=./src/**'
     FAIL  src/test.ts
      ● Test suite failed to run

        Cannot find module './utils.js' from 'src/test.ts'

          3 | // TODO: Remove when this is no longer needed
          4 | test('Dummy test', () => {
        > 5 |     // Boo
            |                  ^
          6 |     parseCoordinates('asd')
          7 | })
          8 |

          at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
          at Object.<anonymous> (src/test.ts:5:18)

when we added *any* imports to test.ts.

This isn't breaking anything at the moment but is needed in order for us to have any meaningful tests.