### PR TITLE
Provide explicit return types everywhere

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ function groupJourneyIntoLegs(journey: Record<string, string>): Record<number, L
     }, {} as Record<number, LegFromCSV>)
 }
 
-async function main() {
+async function main(): Promise<void> {
     const pathToCSVFile = process.argv[2]
     if (!process.env.LUNE_API_KEY) {
         console.log('Please set the LUNE_API_KEY environment variable')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ enum Column {
  * Remove any entries with a falsy key or value (i.e. empty string or null)
  * @param journey
  */
-export function trimAndRemoveEmptyEntries(journey: Record<string, string>) {
+export function trimAndRemoveEmptyEntries(journey: Record<string, string>): Record<string, string> {
     return Object.entries(journey).reduce((acc, [key, value]) => {
         const trimmedKey = key.trim()
         const trimmedValue = value.trim()
@@ -55,7 +55,7 @@ export function mapLegToLocation(leg: LegFromCSV): Address | GeographicCoordinat
  * @param coordinates A string of the following form: "lat <number> lon <number>"
  */
 function parseCoordinates(coordinates: string): GeographicCoordinates {
-    function bail() {
+    function bail(): never {
         throw new Error(
             `Coordinates must be formatted like this: "lat 12.345 lon -12.345", got: "${coordinates}"`,
         )
@@ -77,7 +77,7 @@ function parseCoordinates(coordinates: string): GeographicCoordinates {
     return { lat, lon }
 }
 
-export async function parseCSV(filename: string) {
+export async function parseCSV(filename: string): Promise<any[]> {
     const promise = new Promise((resolve, reject) => {
         createReadStream(filename).pipe(
             parse(
@@ -100,7 +100,7 @@ export function writeResultsToCSV({
     inputs: Record<string, string>[]
     results: EstimateResult[]
     outputFilePath: string
-}) {
+}): void {
     // We'll be modifying the inputs inside – deep copy them so that our
     // changes aren't visible outside this function.
     inputs = inputs.map((i) => ({ ...i }))


### PR DESCRIPTION
Easier to see what the code does at a glance (some functions return something useful, some don't), easier to work with the code and review.