### PR TITLE
Bump the version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lune-shipping-csv-tool",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "nodemon",


### PR DESCRIPTION
Incrementing the major number to make it clear we're breaking compatibility here (and we are, in at least one case: the program expects an environment variable named LUNE_API_KEY now, used to be API_KEY).