### PR TITLE
Give npm EACCES error solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 (typically Terminal on OSX or Command Prompt on Windows).
     * If you get a `EACCES: permission denied` error, there are multiple ways to solve the issue, pick one:
         1. follow instructions [here](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally).
-        2. prefix the above command with `sudo.`
+        2. prefix the above command with `sudo`, to run the above command as Super User.
 3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
 will result in an error `Please set the LUNE_API_KEY environment variable`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 
 1. Install Node if you don't have it already: https://nodejs.org/en/
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
-(typically Terminal on OSX or Command Prompt on Windows)
+(typically Terminal on OSX or Command Prompt on Windows). If you get a `EACCES: permission denied` error, prefix the above command with `sudo.`
 3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
 will result in an error `Please set the LUNE_API_KEY environment variable`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 
 1. Install Node if you don't have it already: https://nodejs.org/en/
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
-(typically Terminal on OSX or Command Prompt on Windows). If you get a `EACCES: permission denied` error, prefix the above command with `sudo.`
+(typically Terminal on OSX or Command Prompt on Windows).
+    * If you get a `EACCES: permission denied` error, there are multiple ways to solve the issue, pick one:
+        1. follow instructions [here](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally).
+        2. prefix the above command with `sudo.`
 3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
 will result in an error `Please set the LUNE_API_KEY environment variable`
 


### PR DESCRIPTION
Customers who get the `EACCES: permission denied` when running `npm` don't know how to proceed.

Explain a possible solution.