### PR TITLE
Rename lune-csv-calculator to lune-shipping-csv-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is supported on Unix-like (Linux, BSD, macOS etc.) and Windows.
 1. Install Node if you don't have it already: https://nodejs.org/en/
 2. Install lune-shipping-csv-tool globally via running command `npm install -g lune-shipping-csv-tool` in a command-line interpreter 
 (typically Terminal on OSX or Command Prompt on Windows)
-3. If the installation was successfully you should be able to run `lune-csv-calculator` in the command-line interpreter although this
+3. If the installation was successfully you should be able to run `lune-shipping-csv-tool` in the command-line interpreter although this
 will result in an error `Please set the LUNE_API_KEY environment variable`
 
 Now follow the [How to use](#how-to-use) instructions.
@@ -38,7 +38,7 @@ This requires a Unix-like operating system (Linux, BSD, macOS, Windows with WSL 
 5. Run the utility via `npm run start` or `yarn start` depending on your package manager of choice
 
 Now follow the [How to use](#how-to-use) instructions. Remember to mentally replace all
-`lune-csv-calculator` occurrences with `yarn start` (or `npm run start`, if you use `npm`) – you
+`lune-shipping-csv-tool` occurrences with `yarn start` (or `npm run start`, if you use `npm`) – you
 are running the development version after all.
 
 Run `git` commands to update the local clone of the repository with the latest upstream changes
@@ -67,13 +67,13 @@ to understand the format. We have documented [The CSV Input format](#the-csv-inp
 Then to actually run the tool:
 
 ```bash
-lune-csv-calculator <path to the input CSV file>
+lune-shipping-csv-tool <path to the input CSV file>
 ```
 
 The output file will appear in the current directory. If you want to define the output directory:
 
 ```bash
-lune-csv-calculator <path to the input CSV file> -o <path to the output directory>
+lune-shipping-csv-tool <path to the input CSV file> -o <path to the output directory>
 ```
 
 ## The CSV Input format

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lune-climate/lune-csv-calculator.git"
+    "url": "git+https://github.com/lune-climate/lune-shipping-csv-tool.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/lune-climate/lune-csv-calculator/issues"
+    "url": "https://github.com/lune-climate/lune-shipping-csv-tool/issues"
   },
-  "homepage": "https://github.com/lune-climate/lune-csv-calculator#readme",
+  "homepage": "https://github.com/lune-climate/lune-shipping-csv-tool#readme",
   "dependencies": {
     "@lune-climate/lune": "^2.2.7",
     "cli-progress": "^3.12.0",
@@ -49,6 +49,6 @@
     "typescript": "^4.9.5"
   },
   "bin": {
-    "lune-csv-calculator": "./build/index.js"
+    "lune-shipping-csv-tool": "./build/index.js"
   }
 }


### PR DESCRIPTION
The project is called `lune-shipping-csv-tool`, call the executable
`lune-shipping-csv-tool`.

This is standard `npm` practice.

Also, some links to Github were wrong.