### PR TITLE
Remove `preinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start": "npm run build && node build/index.js",
     "fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts",
-    "preinstall": "rm -rf build/*",
     "ci": "yarn lint && yarn test --coverage --collectCoverageFrom='./src/**'"
   },
   "repository": {


### PR DESCRIPTION
`preinstall` runs also when this package is being installed:
https://docs.npmjs.com/cli/v9/using-npm/scripts

This results in an empty `build/* directory, which means the executable
cannot be executed because it is deleted when being installed.
