### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lune-shipping-csv-tool",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "dev": "nodemon",


### PR DESCRIPTION
Bumping major version: the executable name has changed to
lune-shipping-csv-tool.
