### PR TITLE
Expand API errors if present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,11 +205,9 @@ async function main(): Promise<void> {
             const description = [
                 apiError.description,
                 ...[
-                    ...[
-                        (apiError.errors?.errors ?? []).map(
-                            ({ errorCode, message }) => `${errorCode}: ${message}`,
-                        ),
-                    ],
+                    (apiError.errors?.errors ?? []).map(
+                        ({ errorCode, message }) => `${errorCode}: ${message}`,
+                    ),
                 ],
             ].join('; ')
             if (!shouldRetry) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,12 +202,21 @@ async function main(): Promise<void> {
                     statusCode === 429)
             // Other 4xx errors are definitely not good for retrying, they're a sign of
             // programming errors or input data issues and need to be fixed on our side.
-            const description = apiError.description || apiError.errors?.errors[0].toString()
+            const description = [
+                apiError.description,
+                ...[
+                    ...[
+                        (apiError.errors?.errors ?? []).map(
+                            ({ errorCode, message }) => `${errorCode}: ${message}`,
+                        ),
+                    ],
+                ],
+            ].join('; ')
             if (!shouldRetry) {
                 console.log(`Failed to create estimate for ${journey.shipment_id}: `, description)
                 // TODO: This type assertion shouldn't be necessary, we won't ever get
                 // undefined here
-                estimates.push({ err: description as string })
+                estimates.push({ err: description })
                 break
             }
 


### PR DESCRIPTION
This increases the possibility for clients to understand what they are doing wrong.

Previously, passing an incorrectly formatted `amount` would show
`The request is invalid. Parameters may be missing or are invalid`
which is not enough for debugging inputs swiftly.

Now you get:
```
"The request is invalid. Parameters may be missing or are invalid; validation_error: Provided data does not match the defined schema.: .body.shipment.mass.amount should match pattern ""^[0-9]+(\.[0-9]+)?$"", .body.shipment.containers should have required property 'containers', .body.shipment.mass.amount should match pattern ""^[0-9]+(\.[0-9]+)?$"", .body.shipment should match exactly one schema in oneOf"
```
