### PR TITLE
Protect against unexpected units returned by the API

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,9 @@ import fs from 'fs'
 
 import {
     Address,
+    Distance,
     GeographicCoordinates,
+    MassUnit,
     MultiLegShippingEmissionEstimate,
 } from '@lune-climate/lune'
 import { parse } from 'csv-parse'
@@ -120,8 +122,17 @@ export function writeResultsToCSV({
             csvRow[Column.TOTAL_DISTANCE_KM] = estimate.distance.amount
 
             estimate.legs.forEach((leg, legIndex) => {
-                csvRow[`leg${legIndex + 1}_estimated_distance_km`] =
-                    leg.distance !== undefined ? leg.distance.amount : ''
+                let distance: string = ''
+                if (leg.distance !== undefined) {
+                    if (leg.distance.unit !== Distance.unit.KM) {
+                        throw new Error(`Unexpected distance unit ${leg.distance.unit} returned`)
+                    }
+                    distance = leg.distance.amount
+                }
+                csvRow[`leg${legIndex + 1}_estimated_distance_km`] = distance
+                if (leg.mass.unit !== MassUnit.T) {
+                    throw new Error(`Unexpected mass unit ${leg.mass.unit} returned`)
+                }
                 csvRow[`leg${legIndex + 1}_total_tco2`] = leg.mass.amount
             })
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,7 +122,7 @@ export function writeResultsToCSV({
             csvRow[Column.TOTAL_DISTANCE_KM] = estimate.distance.amount
 
             estimate.legs.forEach((leg, legIndex) => {
-                let distance: string = ''
+                let distance = ''
                 if (leg.distance !== undefined) {
                     if (leg.distance.unit !== Distance.unit.KM) {
                         throw new Error(`Unexpected distance unit ${leg.distance.unit} returned`)


### PR DESCRIPTION
The code has been making assumptions that the API returns distances in kilometers and CO2 amounts in tonnes.

While the API does do that (currently) it'd be great for the code to actually varify this assumption so we at least know in case it doesn't happen to be true.