### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This tool will be deprecated soon in favour of the dashboard tool.

Let's start by disabling dependabot.